### PR TITLE
INT-398 Add S3G port to Pachyderm datastore

### DIFF
--- a/syncer/sync.py
+++ b/syncer/sync.py
@@ -79,8 +79,9 @@ def update_repos():
                     "datastoreType": "Pachyderm",
                     "credential": auth,
                     "properties": {
-                        "pachd_service_host": os.environ["PACHD_SERVICE_HOST"],
-                        "pachd_service_port": os.environ["PACHD_SERVICE_PORT"],
+                        "pachd_service_host": os.environ.get("PACHD_SERVICE_HOST", "localhost"),
+                        "pachd_service_port": os.environ.get("PACHD_SERVICE_PORT", 30650),
+                        "pachd_s3g_port": os.environ.get("PACHD_S3G_PORT", 30600),
                     },
                 },
             },

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,6 +81,7 @@ export AZURE_ML_WORKSPACE_NAME="${local.machine_learning_workspace_name}"
 
 export PACHD_SERVICE_HOST="localhost"
 export PACHD_SERVICE_PORT="30650"
+export PACHD_S3G_PORT="30600"
 
 export PACHYDERM_SYNCER_MODE="${var.pachyderm_syncer_mode}"
 export SKIP_PACHYDERM_DEPLOY="${var.skip_pachyderm_deploy}"


### PR DESCRIPTION
This PR makes the S3G port configurable via environment variables when the user provisions the Syncer VM. This value then gets consumed by the Azure ML client library to connect to the S3G.